### PR TITLE
Re-written S3 Server Side Encryption dynamic block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_versioning" "this" {
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
-  dynamic "rule"{
+  dynamic "rule" {
     for_each = var.versioning_enabled == true && var.enable_centralized_logging == true ? [true] : []
     content {
       apply_server_side_encryption_by_default {


### PR DESCRIPTION
- S3 Bucket refactoring - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#s3-bucket-refactor
- S3 Bucket refactoring - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#s3-bucket-refactor
- Removed acl from aws_s3_bucket.this resource
- Changed other references from aws_s3_bucket.bucket to aws_s3_bucket.this
- Testing dynamic block to enable or disable versioning
- Re-worked dynamic blocks
- testing re-worked dynamic blocks
- Commiting dynamic block changes after successful terraform validation
- added missing bucket id attribute type
- dynamic block in s3 server side configuration re-written
