### PR TITLE
Count Var instead of dynamic blocks

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -45,6 +45,18 @@ variable "enable_centralized_logging" {
   default     = false
 }
 
+variable "enable_replication" {
+  description = "Enable replication for logging bucket"
+  type        = bool
+  default     = false
+}
+
+variable "enable_server_side_encryption" {
+  description = "Enable server-side encryption"
+  type        = bool
+  default     = false
+}
+
 variable "s3_destination_bucket_name" {
   description = "Centralized Logging Bucket Name"
   type        = string


### PR DESCRIPTION
- S3 Bucket refactoring - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#s3-bucket-refactor
- S3 Bucket refactoring - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#s3-bucket-refactor
- Removed acl from aws_s3_bucket.this resource
- Changed other references from aws_s3_bucket.bucket to aws_s3_bucket.this
- Testing dynamic block to enable or disable versioning
- Re-worked dynamic blocks
- testing re-worked dynamic blocks
- Commiting dynamic block changes after successful terraform validation
- added missing bucket id attribute type
- dynamic block in s3 server side configuration re-written
- re-working dynamic blocks
- Switching to count variable for conditional creation of encryption and replication rules
