### PR TITLE
Storage class typo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
     transition {
       days = var.transition_IA
-      storage_class = "STANDARD_ID"
+      storage_class = "STANDARD_IA"
     }
 
     transition {


### PR DESCRIPTION
- S3 Bucket refactoring - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#s3-bucket-refactor
- S3 Bucket refactoring - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#s3-bucket-refactor
- Removed acl from aws_s3_bucket.this resource
- Changed other references from aws_s3_bucket.bucket to aws_s3_bucket.this
- Testing dynamic block to enable or disable versioning
- Re-worked dynamic blocks
- testing re-worked dynamic blocks
- Commiting dynamic block changes after successful terraform validation
- added missing bucket id attribute type
- dynamic block in s3 server side configuration re-written
- re-working dynamic blocks
- Switching to count variable for conditional creation of encryption and replication rules
- STANDARD_IA storage class had a typo
